### PR TITLE
Document base Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Answer all the questions, and you'll have your new project!
 Inside `[project_destination_directory]/[project_slug]/README.md` you will have more
 documentation explaining how to use and configure your newly created project.
 
+## Python Libraries
+
+As an optionated template, we choose as dependencies some Python libraries and frameworks that
+are configured and made available to be used during the project development. Some of them
+will be installed only if requested when answering the questions in the project creation.
+
+- [argon2-cffi](https://github.com/hynek/argon2_cffi) - it allows to use Argon2 as password hasher in Django, as [recommended](https://docs.djangoproject.com/en/4.1/topics/auth/passwords/#using-argon2-with-django) by Django docs.
+- [celery](https://github.com/celery/celery) - Distributed Task Queue
+- [crispy-bootstrap5](https://pypi.org/project/crispy-bootstrap5/) - Bootstrap5 template pack for django-crispy-forms.
+- [django](https://www.djangoproject.com/) - The web framework for perfectionists with deadlines.
+- [django-allauth](https://github.com/pennersr/django-allauth) - set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication. It considers that you are using regular Django Templates.
+- [django-anymail](https://pypi.org/project/django-anymail/) - Django email backends for different providers (as Amazon SES, Mailgun, SMTP, etc).
+- [django-celery-beat](https://github.com/celery/django-celery-beat) - Celery Periodic Tasks backed by the Django ORM.
+- [django-compressor](https://github.com/django-compressor/django-compressor) - Compresses linked and inline javascript or CSS into a single cached file.
+- [django-cors-headers](https://github.com/adamchainz/django-cors-headers) - Django app for handling the server headers required for Cross-Origin Resource Sharing (CORS). Needs to be configured for [REST framework](https://www.django-rest-framework.org/topics/ajax-csrf-cors/#cors).
+- [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) - improve rendering of Django forms. It considers that you are using regular Django Templates.
+- [django-environ](https://django-environ.readthedocs.io/en/stable/) -  allows you to utilize 12-factor inspired environment variables to configure your Django application. It is being used in all project settings files.
+- [django-model-utils](https://django-model-utils.readthedocs.io/en/stable/) - mixins and utilities for your project. It is not explicitly used in our generated project but available if wanted to be used.
+- [django-redis](https://github.com/jazzband/django-redis) - Full featured redis cache backend for Django.
+- [django-storages](https://pypi.org/project/django-storages/) - Support for many storage backends in Django.
+- [djangorestframework](https://github.com/encode/django-rest-framework) - Django REST framework is a powerful and flexible toolkit for building Web APIs.
+- [drf-spectacular](https://github.com/tfranzel/drf-spectacular) - Sane and flexible OpenAPI 3 schema generation for Django REST framework. Useful when testing and developing APIs.
+- [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery distributed task queue.
+- [redis](https://github.com/redis/redis-py) - Redis Python Client. Required by Celery as we use Redis as [broker](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#using-redis)
+- [Pillow](https://pypi.org/project/Pillow/) - Python Imaging Library. Required if we have `models.ImageField` fields in our project.
+
 ## Development on the Cookie Cutter
 
 When making changes to the Cookie Cutter, keep the following in mind:

--- a/README.md
+++ b/README.md
@@ -41,32 +41,6 @@ Answer all the questions, and you'll have your new project!
 Inside `[project_destination_directory]/[project_slug]/README.md` you will have more
 documentation explaining how to use and configure your newly created project.
 
-## Python Libraries
-
-As an optionated template, we choose as dependencies some Python libraries and frameworks that
-are configured and made available to be used during the project development. Some of them
-will be installed only if requested when answering the questions in the project creation.
-
-- [argon2-cffi](https://github.com/hynek/argon2_cffi) - it allows to use Argon2 as password hasher in Django, as [recommended](https://docs.djangoproject.com/en/4.1/topics/auth/passwords/#using-argon2-with-django) by Django docs.
-- [celery](https://github.com/celery/celery) - Distributed Task Queue
-- [crispy-bootstrap5](https://pypi.org/project/crispy-bootstrap5/) - Bootstrap5 template pack for django-crispy-forms.
-- [django](https://www.djangoproject.com/) - The web framework for perfectionists with deadlines.
-- [django-allauth](https://github.com/pennersr/django-allauth) - set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication. It considers that you are using regular Django Templates.
-- [django-anymail](https://pypi.org/project/django-anymail/) - Django email backends for different providers (as Amazon SES, Mailgun, SMTP, etc).
-- [django-celery-beat](https://github.com/celery/django-celery-beat) - Celery Periodic Tasks backed by the Django ORM.
-- [django-compressor](https://github.com/django-compressor/django-compressor) - Compresses linked and inline javascript or CSS into a single cached file.
-- [django-cors-headers](https://github.com/adamchainz/django-cors-headers) - Django app for handling the server headers required for Cross-Origin Resource Sharing (CORS). Needs to be configured for [REST framework](https://www.django-rest-framework.org/topics/ajax-csrf-cors/#cors).
-- [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) - improve rendering of Django forms. It considers that you are using regular Django Templates.
-- [django-environ](https://django-environ.readthedocs.io/en/stable/) -  allows you to utilize 12-factor inspired environment variables to configure your Django application. It is being used in all project settings files.
-- [django-model-utils](https://django-model-utils.readthedocs.io/en/stable/) - mixins and utilities for your project. It is not explicitly used in our generated project but available if wanted to be used.
-- [django-redis](https://github.com/jazzband/django-redis) - Full featured redis cache backend for Django.
-- [django-storages](https://pypi.org/project/django-storages/) - Support for many storage backends in Django.
-- [djangorestframework](https://github.com/encode/django-rest-framework) - Django REST framework is a powerful and flexible toolkit for building Web APIs.
-- [drf-spectacular](https://github.com/tfranzel/drf-spectacular) - Sane and flexible OpenAPI 3 schema generation for Django REST framework. Useful when testing and developing APIs.
-- [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery distributed task queue.
-- [redis](https://github.com/redis/redis-py) - Redis Python Client. Required by Celery as we use Redis as [broker](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#using-redis)
-- [Pillow](https://pypi.org/project/Pillow/) - Python Imaging Library. Required if we have `models.ImageField` fields in our project.
-
 ## Development on the Cookie Cutter
 
 When making changes to the Cookie Cutter, keep the following in mind:
@@ -74,6 +48,31 @@ When making changes to the Cookie Cutter, keep the following in mind:
 - update pins in requirements/*.in files but *don't\* commit the compiled requirements.txt
   files to the repo.
 - update to latest Python supported by Django. For Django 4.1 this is 3.8, 3.9, and 3.10.
+
+## Python Libraries
+
+This template includes the Python libraries listed below. Some of them
+will be installed only if requested when answering the questions in the project creation.
+
+- [argon2-cffi](https://github.com/hynek/argon2_cffi) - enables the use of the Argon2 password hasher in Django, as [recommended](https://docs.djangoproject.com/en/4.1/topics/auth/passwords/#using-argon2-with-django) by Django docs.
+- [celery](https://github.com/celery/celery) - Distributed Task Queue
+- [crispy-bootstrap5](https://pypi.org/project/crispy-bootstrap5/) - Bootstrap5 template pack for django-crispy-forms.
+- [django](https://www.djangoproject.com/) - The web framework for perfectionists with deadlines.
+- [django-allauth](https://github.com/pennersr/django-allauth) - set of Django applications addressing authentication, registration, account management, as well as 3rd party (social) account authentication. It assumes you are using regular Django Templates.
+- [django-anymail](https://pypi.org/project/django-anymail/) - Django email backends for different providers such as Amazon SES, Mailgun, SMTP, etc.
+- [django-celery-beat](https://github.com/celery/django-celery-beat) - Celery Periodic Tasks backed by the Django ORM.
+- [django-compressor](https://github.com/django-compressor/django-compressor) - Compresses linked and inline javascript or CSS into a single cached file.
+- [django-cors-headers](https://github.com/adamchainz/django-cors-headers) - Django app for handling the server headers required for Cross-Origin Resource Sharing (CORS). Needs to be configured for [REST framework](https://www.django-rest-framework.org/topics/ajax-csrf-cors/#cors).
+- [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) - improve rendering of Django forms. It assumes that you are using regular Django Templates.
+- [django-environ](https://django-environ.readthedocs.io/en/stable/) -  allows you to utilize 12-factor inspired environment variables to configure your Django application. It is being used in all project settings files.
+- [django-model-utils](https://django-model-utils.readthedocs.io/en/stable/) - mixins and utilities for your project. It is not explicitly used in our generated project but is available for use in your project.
+- [django-redis](https://github.com/jazzband/django-redis) - Full-featured Redis cache backend for Django.
+- [django-storages](https://pypi.org/project/django-storages/) - Support multiple storage backends in Django.
+- [djangorestframework](https://github.com/encode/django-rest-framework) - Django REST framework is a powerful and flexible toolkit for building Web APIs.
+- [drf-spectacular](https://github.com/tfranzel/drf-spectacular) - Sane and flexible OpenAPI 3 schema generation for Django REST framework. Useful when testing and developing APIs.
+- [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery distributed task queue.
+- [redis](https://github.com/redis/redis-py) - Redis Python client. Required by Celery as we use Redis as [broker](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#using-redis)
+- [Pillow](https://pypi.org/project/Pillow/) - Python Imaging Library. Required if we have `models.ImageField` fields in our project.
 
 ## Development using Kubernetes
 

--- a/{{cookiecutter.project_slug}}/backend/requirements/base.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/base.in
@@ -1,48 +1,26 @@
+argon2-cffi==21.3.0
+crispy-bootstrap5==0.7
+django~=4.1.0
+django-allauth==0.52.0
+django-crispy-forms==1.14.0
+django-environ==0.9.0
+django-model-utils==4.3.1
+django-redis==5.2.0
+Pillow==9.4.0
 
-argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
-astroid==2.12.2
-asttokens==2.0.8
-executing==0.10.0
-Faker==14.0.0
-jsonschema==4.10.0
-Pillow==9.2.0  # https://github.com/python-pillow/Pillow
-pydevd-pycharm==222.3739.43
-Pygments==2.13.0
-python-slugify==6.1.2  # https://github.com/un33k/python-slugify
-pytz==2022.2.1
-{%- if cookiecutter.use_compressor == 'y' %}
-rcssmin==1.1.0
-rjsmin==1.2.0
+{%- if cookiecutter.use_compressor == "y" %}
+django-compressor==4.1
 {%- endif %}
-safety
-setuptools==65.0.1
-stack-data==0.4.0
-tomlkit==0.11.4
 
 {%- if cookiecutter.use_celery == "y" %}
-redis==4.3.4  # https://github.com/redis/redis-py
-hiredis==2.0.0  # https://github.com/redis/hiredis-py
-celery==5.2.7  # pyup: < 6.0  # https://github.com/celery/celery
-flower==1.1.0  # https://github.com/mher/flower
-django-celery-beat==2.4.0  # https://github.com/celery/django-celery-beat
+celery~=5.2.0
+django-celery-beat==2.4.0
+flower==1.2.0
+redis~=4.4.0
 {%- endif %}
 
-# Django
-# ------------------------------------------------------------------------------
-django~=4.1.0  # https://www.djangoproject.com/
-django-environ>=0.9.0  # https://github.com/joke2k/django-environ
-django-model-utils==4.2.0  # https://github.com/jazzband/django-model-utils
-django-allauth==0.51.0  # https://github.com/pennersr/django-allauth
-django-crispy-forms==1.14.0  # https://github.com/django-crispy-forms/django-crispy-forms
-crispy-bootstrap5==0.6  # https://github.com/django-crispy-forms/crispy-bootstrap5
-{%- if cookiecutter.use_compressor == 'y' %}
-django-compressor==4.1  # https://github.com/django-compressor/django-compressor
-{%- endif %}
-django-redis==5.2.0  # https://github.com/jazzband/django-redis
-{%- if cookiecutter.use_drf == 'y' %}
-# Django REST Framework
-djangorestframework==3.13.1  # https://github.com/encode/django-rest-framework
-django-cors-headers==3.13.0 # https://github.com/adamchainz/django-cors-headers
-# DRF-spectacular for api documentation
-drf-spectacular==0.23.1  # https://github.com/tfranzel/drf-spectacular
+{%- if cookiecutter.use_drf == "y" %}
+django-cors-headers==3.13.0
+djangorestframework~=3.14.0
+drf-spectacular==0.25.1
 {%- endif %}


### PR DESCRIPTION
Added documentation of all base Python dependencies of the template. Tried to explain why the dependency is there and how it should be used. A reference for anyone starting to work with the template.

During the process of documenting the base dependencies in our template, I identified some libraries that shouldn't be in a base install of the project, or that are not top-level dependency (i.e. they are already installed when we include some other library). Some could be moved to `local.in` or `test.in` if we consider them really useful.

Removed libraries (and some reasoning):
- `astroid` - developer tool not used in the generated project
- `asttokens` - developer tool not used in the generated project
- `executing` - developer tool not used in the generated project
- `Faker` - testing library dependency of `factory-boy`
- `jsonschema` - JSON Schema validation for Python not used in the generated project
- `pydevd-pycharm` - Debug tool for a specific IDE
- `Pygments`- Syntax highlighting package not used in the generated project
- `pytz` - replaced by built-in [zoneinfo](https://docs.djangoproject.com/en/4.1/releases/4.0/#zoneinfo-default-timezone-implementation) in Django>4.x
- `setuptools` - not needed
- `safety` - security tool not used in the generated project
- `stack-data` - developer tool not used in the generated project
- `tomlkit` - debugging tool not used in the generated project
- `rcssmin` - it is a dependency of `django-compressor`
- `rjsmin` - it is a dependency of `django-compressor`
- `hiredis`- it is a performance boost for `django-redis` and needs to be configured if we want to use it
- `python-slugify` - Django already has a slugify function