### PR TITLE
feat: keep PVs across tilt restart. closes #124

### DIFF
--- a/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
@@ -68,33 +68,14 @@ spec:
             claimName: postgres-pvc
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: postgres-pv
-  labels:
-    type: local
-    environment: dev
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: /mnt/postgres-data
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
-  labels:
-    type: local
-    environment: dev
+  annotations: 
+    tilt.dev/down-policy: keep
 spec:
-  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 500Mi
-  volumeName: postgres-pv


### PR DESCRIPTION
Add annotation to keep persistent volumes across tilt restarts.

Remove any references to named persistent volumes and use dynamic persistent volume provisioning. This works much more reliably with local Kubernetes dev environments like Docker Desktop and Kind. This is also the recommended way to provision storage in cloud agnostic way.